### PR TITLE
Fix trg_scalers sorting in spill_log.py

### DIFF
--- a/bin/spill_log.py
+++ b/bin/spill_log.py
@@ -123,7 +123,7 @@ cb_spill_log_df = (
     )
 )
 
-trg_scalers_df.sort("trg_time")
+trg_scalers_df = trg_scalers_df.drop_nulls().sort("trg_time")
 trg_spill_log_df = (
     windows_df.sort("start_time")
     .join_asof(


### PR DESCRIPTION
The `sort` function does not mutate the input dataframe. Instead it just returns another dataframe with the sorted rows. So, when I was doing `df.sort("...")` I was just sorting and throwing away that df.

This was working OK, because the `trg_scalers` are already sorted by their timestamp. But, there is an edge case when the timestamp is `null` (there was an issue with an event at a lower level). In that case, the df is not actually sorted (nulls between actual timestamps).